### PR TITLE
[FEATURE] Added new method betweenLexoRanks which allows to generate multiple between lexoRank based on user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ const any1LexoRank = LexoRank.min();
 const any2LexoRank = any1LexoRank.genNext().genNext();
 // calculate between
 const betweenLexoRank = any1LexoRank.between(any2LexoRank);
+// calculate between lexoRanks
+const betweenLexoRanks = any1LexoRank.betweenLexoRanks(any2LexoRank, 5);
 ```
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const any2LexoRank = any1LexoRank.genNext().genNext();
 // calculate between
 const betweenLexoRank = any1LexoRank.between(any2LexoRank);
 // calculate between lexoRanks
-const betweenLexoRanks = any1LexoRank.betweenLexoRanks(any2LexoRank, 5);
+const betweenLexoRanks = any1LexoRank.multipleBetween(any2LexoRank, 5);
 ```
 
 ## Related projects

--- a/__tests__/lexoRank.spec.ts
+++ b/__tests__/lexoRank.spec.ts
@@ -64,4 +64,107 @@ describe('LexoRank', () => {
     const between = prevRank.between(nextRank);
     expect(between.toString()).toEqual(expected);
   });
+
+  it('find the nearest power', () => {
+    expect(LexoRank.nearestPowerOfTwo(1)).toEqual(1);
+    expect(LexoRank.nearestPowerOfTwo(5)).toEqual(3);
+    expect(LexoRank.nearestPowerOfTwo(6)).toEqual(3);
+    expect(LexoRank.nearestPowerOfTwo(8)).toEqual(4);
+    expect(LexoRank.nearestPowerOfTwo(15)).toEqual(4);
+    expect(LexoRank.nearestPowerOfTwo(31)).toEqual(5);
+    expect(LexoRank.nearestPowerOfTwo(63)).toEqual(6);
+    expect(LexoRank.nearestPowerOfTwo(124)).toEqual(7);
+    expect(LexoRank.nearestPowerOfTwo(127)).toEqual(7);
+  });
+
+  it('find the betweenLexoRanks for 1 lexoRanks to generate', () => {
+    const minRank = LexoRank.min();
+    const maxRank = LexoRank.max();
+    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 1);
+    expect(lexoRanks.length).toEqual(1);
+    expect(lexoRanks[0].toString()).toEqual('0|hzzzzz:');
+  });
+
+  it('find the betweenLexoRanks for 2 lexoRanks to generate', () => {
+    const minRank = LexoRank.min();
+    const maxRank = LexoRank.max();
+    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 2);
+    expect(lexoRanks.length).toEqual(2);
+    expect(lexoRanks[0].toString()).toEqual('0|8zzzzz:');
+    expect(lexoRanks[1].toString()).toEqual('0|hzzzzz:');
+    expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
+  });
+
+  it('find the betweenLexoRanks for 2 lexoRanks when one lexoRank is long in length', () => {
+    const maxRank = LexoRank.parse('0|i00006:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzr');
+    const minRank = LexoRank.parse('0|i00006:zzr');
+    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 2);
+    expect(lexoRanks.length).toEqual(2);
+    expect(lexoRanks[0].toString()).toEqual('0|i00006:zzt');
+    expect(lexoRanks[1].toString()).toEqual('0|i00006:zzv');
+    expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
+  });
+
+  it('find the betweenLexoRanks for 3 lexoRanks to generate', () => {
+    const minRank = LexoRank.min();
+    const maxRank = LexoRank.max();
+    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 3);
+    expect(lexoRanks.length).toEqual(3);
+    expect(lexoRanks[0].toString()).toEqual('0|8zzzzz:');
+    expect(lexoRanks[1].toString()).toEqual('0|hzzzzz:');
+    expect(lexoRanks[2].toString()).toEqual('0|qzzzzz:');
+    expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
+  });
+
+  it('find the betweenLexoRanks for 4 lexoRanks to generate', () => {
+    const minRank = LexoRank.min();
+    const maxRank = LexoRank.max();
+    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 4);
+    expect(lexoRanks.length).toEqual(4);
+    expect(lexoRanks[0].toString()).toEqual('0|4hzzzz:');
+    expect(lexoRanks[1].toString()).toEqual('0|8zzzzz:');
+    expect(lexoRanks[2].toString()).toEqual('0|dhzzzz:');
+    expect(lexoRanks[3].toString()).toEqual('0|hzzzzz:');
+    expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
+  });
+
+  it('find the betweenLexoRanks for 7 lexoRanks to generate', () => {
+    const minRank = LexoRank.min();
+    const maxRank = LexoRank.max();
+    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 7);
+    expect(lexoRanks.length).toEqual(7);
+    expect(lexoRanks[0].toString()).toEqual('0|4hzzzz:');
+    expect(lexoRanks[1].toString()).toEqual('0|8zzzzz:');
+    expect(lexoRanks[2].toString()).toEqual('0|dhzzzz:');
+    expect(lexoRanks[3].toString()).toEqual('0|hzzzzz:');
+    expect(lexoRanks[4].toString()).toEqual('0|mhzzzz:');
+    expect(lexoRanks[5].toString()).toEqual('0|qzzzzz:');
+    expect(lexoRanks[6].toString()).toEqual('0|vhzzzz:');
+    expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
+  });
+
+  it('find the betweenLexoRanks for 8 lexoRanks when one lexoRank is long in length', () => {
+    const maxRank = LexoRank.parse('0|i00006:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzr');
+    const minRank = LexoRank.parse('0|i00006:zzr');
+    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 8);
+    expect(lexoRanks.length).toEqual(8);
+    expect(lexoRanks[0].toString()).toEqual('0|i00006:zzri');
+    expect(lexoRanks[1].toString()).toEqual('0|i00006:zzs');
+    expect(lexoRanks[2].toString()).toEqual('0|i00006:zzsi');
+    expect(lexoRanks[3].toString()).toEqual('0|i00006:zzt');
+    expect(lexoRanks[4].toString()).toEqual('0|i00006:zzti');
+    expect(lexoRanks[5].toString()).toEqual('0|i00006:zzu');
+    expect(lexoRanks[6].toString()).toEqual('0|i00006:zzui');
+    expect(lexoRanks[7].toString()).toEqual('0|i00006:zzv');
+    expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
+  });
+
+  function checkSortedInAscendingOrder(arr) {
+    for (let i = 0; i < arr.length - 1; i++) {
+      if (arr[i] > arr[i + 1]) {
+        return false;
+      }
+    }
+    return true;
+  }
 });

--- a/__tests__/lexoRank.spec.ts
+++ b/__tests__/lexoRank.spec.ts
@@ -66,49 +66,53 @@ describe('LexoRank', () => {
   });
 
   it('find the nearest power', () => {
-    expect(LexoRank.nearestPowerOfTwo(1)).toEqual(1);
-    expect(LexoRank.nearestPowerOfTwo(5)).toEqual(3);
-    expect(LexoRank.nearestPowerOfTwo(6)).toEqual(3);
-    expect(LexoRank.nearestPowerOfTwo(8)).toEqual(4);
-    expect(LexoRank.nearestPowerOfTwo(15)).toEqual(4);
-    expect(LexoRank.nearestPowerOfTwo(31)).toEqual(5);
-    expect(LexoRank.nearestPowerOfTwo(63)).toEqual(6);
-    expect(LexoRank.nearestPowerOfTwo(124)).toEqual(7);
-    expect(LexoRank.nearestPowerOfTwo(127)).toEqual(7);
+    expect(LexoRank.binaryDepthToInsertRanks(1)).toEqual(1);
+    expect(LexoRank.binaryDepthToInsertRanks(2)).toEqual(2);
+    expect(LexoRank.binaryDepthToInsertRanks(3)).toEqual(2);
+    expect(LexoRank.binaryDepthToInsertRanks(4)).toEqual(3);
+    expect(LexoRank.binaryDepthToInsertRanks(5)).toEqual(3);
+    expect(LexoRank.binaryDepthToInsertRanks(6)).toEqual(3);
+    expect(LexoRank.binaryDepthToInsertRanks(7)).toEqual(3);
+    expect(LexoRank.binaryDepthToInsertRanks(8)).toEqual(4);
+    expect(LexoRank.binaryDepthToInsertRanks(15)).toEqual(4);
+    expect(LexoRank.binaryDepthToInsertRanks(31)).toEqual(5);
+    expect(LexoRank.binaryDepthToInsertRanks(63)).toEqual(6);
+    expect(LexoRank.binaryDepthToInsertRanks(124)).toEqual(7);
+    expect(LexoRank.binaryDepthToInsertRanks(127)).toEqual(7);
   });
 
-  it('find the betweenLexoRanks for 1 lexoRanks to generate', () => {
+  it('find the multipleBetween for 1 lexoRanks to generate', () => {
     const minRank = LexoRank.min();
     const maxRank = LexoRank.max();
-    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 1);
+    const lexoRanks: LexoRank[] = minRank.multipleBetween(maxRank, 1);
     expect(lexoRanks.length).toEqual(1);
     expect(lexoRanks[0].toString()).toEqual('0|hzzzzz:');
   });
 
-  it('find the betweenLexoRanks for 2 lexoRanks to generate', () => {
+  it('find the multipleBetween for 2 lexoRanks to generate', () => {
     const minRank = LexoRank.min();
     const maxRank = LexoRank.max();
-    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 2);
+    const lexoRanks: LexoRank[] = minRank.multipleBetween(maxRank, 2);
     expect(lexoRanks.length).toEqual(2);
     expect(lexoRanks[0].toString()).toEqual('0|8zzzzz:');
     expect(lexoRanks[1].toString()).toEqual('0|hzzzzz:');
     expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
   });
 
-  it('find the betweenLexoRanks for 2 lexoRanks when one lexoRank is long in length', () => {
+  it('find the multipleBetween for 2 lexoRanks when one lexoRank is long in length', () => {
     const maxRank = LexoRank.parse('0|i00006:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzr');
     const minRank = LexoRank.parse('0|i00006:zzr');
-    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 2);
+    const lexoRanks: LexoRank[] = minRank.multipleBetween(maxRank, 2);
     expect(lexoRanks.length).toEqual(2);
     expect(lexoRanks[0].toString()).toEqual('0|i00006:zzt');
     expect(lexoRanks[1].toString()).toEqual('0|i00006:zzv');
     expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
   });
 
-  it('find the betweenLexoRanks for 3 lexoRanks to generate', () => {
+  it('find the multipleBetween for 3 lexoRanks to generate', () => {
     const minRank = LexoRank.min();
     const maxRank = LexoRank.max();
-    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 3);
+    const lexoRanks: LexoRank[] = minRank.multipleBetween(maxRank, 3);
     expect(lexoRanks.length).toEqual(3);
     expect(lexoRanks[0].toString()).toEqual('0|8zzzzz:');
     expect(lexoRanks[1].toString()).toEqual('0|hzzzzz:');
@@ -116,10 +120,10 @@ describe('LexoRank', () => {
     expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
   });
 
-  it('find the betweenLexoRanks for 4 lexoRanks to generate', () => {
+  it('find the multipleBetween for 4 lexoRanks to generate', () => {
     const minRank = LexoRank.min();
     const maxRank = LexoRank.max();
-    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 4);
+    const lexoRanks: LexoRank[] = minRank.multipleBetween(maxRank, 4);
     expect(lexoRanks.length).toEqual(4);
     expect(lexoRanks[0].toString()).toEqual('0|4hzzzz:');
     expect(lexoRanks[1].toString()).toEqual('0|8zzzzz:');
@@ -128,10 +132,10 @@ describe('LexoRank', () => {
     expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
   });
 
-  it('find the betweenLexoRanks for 7 lexoRanks to generate', () => {
+  it('find the multipleBetween for 7 lexoRanks to generate', () => {
     const minRank = LexoRank.min();
     const maxRank = LexoRank.max();
-    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 7);
+    const lexoRanks: LexoRank[] = minRank.multipleBetween(maxRank, 7);
     expect(lexoRanks.length).toEqual(7);
     expect(lexoRanks[0].toString()).toEqual('0|4hzzzz:');
     expect(lexoRanks[1].toString()).toEqual('0|8zzzzz:');
@@ -143,10 +147,10 @@ describe('LexoRank', () => {
     expect(checkSortedInAscendingOrder(lexoRanks)).toEqual(true);
   });
 
-  it('find the betweenLexoRanks for 8 lexoRanks when one lexoRank is long in length', () => {
+  it('find the multipleBetween for 8 lexoRanks when one lexoRank is long in length', () => {
     const maxRank = LexoRank.parse('0|i00006:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzr');
     const minRank = LexoRank.parse('0|i00006:zzr');
-    const lexoRanks: LexoRank[] = minRank.betweenLexoRanks(maxRank, 8);
+    const lexoRanks: LexoRank[] = minRank.multipleBetween(maxRank, 8);
     expect(lexoRanks.length).toEqual(8);
     expect(lexoRanks[0].toString()).toEqual('0|i00006:zzri');
     expect(lexoRanks[1].toString()).toEqual('0|i00006:zzs');

--- a/src/lexoRank/lexoRank.ts
+++ b/src/lexoRank/lexoRank.ts
@@ -311,23 +311,27 @@ export class LexoRank {
     return new LexoRank(this.bucket, LexoRank.between(this.decimal, other.decimal));
   }
 
-  public betweenLexoRanks(other: LexoRank, ranksToGenerate: number): LexoRank[] {
+  public multipleBetween(other: LexoRank, ranksToGenerate: number): LexoRank[] {
 
     if (!this.bucket.equals(other.bucket)) {
       throw new Error('Between works only within the same bucket');
     }
 
-    if (ranksToGenerate == 0) {
-      return [];
+    if (ranksToGenerate <= 0) {
+      throw new Error(`'ranksToGenerate' should be greater than 0`);
     }
 
-    let newLeft: LexoRank = this;
-    let newRight: LexoRank = other;
+    if (ranksToGenerate == 1) {
+      return [this.between(other)];
+    }
+
+    let left: LexoRank = this;
+    let right: LexoRank = other;
 
     const cmp = this.decimal.compareTo(other.decimal);
     if (cmp > 0) {
-      newLeft = other;
-      newRight = this;
+      left = other;
+      right = this;
     }
 
     if (cmp === 0) {
@@ -343,15 +347,11 @@ export class LexoRank {
       );
     }
 
-    if (ranksToGenerate == 1) {
-      return [new LexoRank(newLeft.bucket, LexoRank.between(newLeft.decimal, newRight.decimal))];
-    }
-
-    const binaryDepth: number = LexoRank.nearestPowerOfTwo(ranksToGenerate);
+    const binaryDepth: number = LexoRank.binaryDepthToInsertRanks(ranksToGenerate);
 
     const lexoRanks: LexoRank[] = [];
 
-    LexoRank.prepareLexoRanks(newLeft, newRight, 1, binaryDepth, lexoRanks);
+    LexoRank.prepareLexoRanks(left, right, 1, binaryDepth, lexoRanks);
 
     return lexoRanks.slice(0, ranksToGenerate);
   }
@@ -431,7 +431,7 @@ export class LexoRank {
   }
 
   // Visible for unit test
-  public static nearestPowerOfTwo(noOfRanks: number): number {
+  public static binaryDepthToInsertRanks(noOfRanks: number): number {
     if (noOfRanks < 1) return 0;
 
     let power = 1;


### PR DESCRIPTION
Closes issue reported on upstream repo: https://github.com/kvandake/lexorank-ts/issues/28.

A new method betweenLexoRanks has been introduced to efficiently generate the intermediate lexoRank values in bulk. Previously, the process involved identifying the exact middle rank each time, leading to rapid growth of lexoRanks. The updated approach involves creating a slice based on the desired number of lexoRanks, optimizing the computation by using slices instead of repeatedly halving.